### PR TITLE
Add ROADMAP.md and expand telOS integration documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -114,6 +114,20 @@ The rapid recursion loop (MAGI analysis -> code introspection -> optimization pr
 
 Retained as-is.
 
+## Long-Term Substrate: telOS
+
+Maestro's WeightHost/WeightNode abstraction was designed independently but is architecturally convergent with telOS. In telOS, the vector database *is* the address space — there is no process table, no file hierarchy, no PID namespace. Resources are located by semantic proximity to intent vectors, not by path or numeric identifier.
+
+Under this model:
+- A **WeightHost** becomes a vector-addressed node in the telOS address space, located by its capability signature
+- A **WeightNode** is a resolved inference endpoint, reachable via intent query rather than TCP socket
+- The quorum layer becomes a semantic consensus operation over the vector substrate, not a network vote over HTTP
+- The R2 epistemic ledger maps naturally to an append-only vector index with time-weighted decay
+
+This is not vaporware architectural speculation. It is the intended end state of the infrastructure Blake is currently building, and every design decision in Maestro should be evaluated against whether it survives the Python→Rust→telOS transition with minimal refactor cost.
+
+---
+
 ## Design Decisions Follow From the Thesis
 
 Every architectural choice in Maestro derives from the core inversion:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,6 +105,47 @@ through continuous epistemic measurement.*
 
 ---
 
+## Phase 5: Plugin Architecture & Mod Manager
+
+*Extensible orchestration with hot-swappable modules.*
+
+- [ ] **Mod Manager** — Loading/unloading Maestro modules like video game mods
+- [ ] **Weight State Snapshots** — Save and restore snapshots for testing configuration deltas
+- [ ] **Hook Points in Hot Path** — Pre-routing, post-response, pre-consensus, post-consensus
+
+---
+
+## Phase 6: Proof-of-Storage Distributed Inference
+
+*Inference as a verifiable distributed resource.*
+
+- [ ] **ComputeNodeRegistry** — Topology-aware registry for compute nodes
+- [ ] **Shard Agent Routing** — Routing inference across storage nodes
+- [ ] **R2 Integration for Node Reputation** — Reputation scoring based on R2 quality data
+- [ ] **Activation Passing** — Activation passing between pipeline stages
+
+---
+
+## Phase 7: Local Model Support
+
+*Local hardware as first-class inference infrastructure.*
+
+- [ ] **Local WeightNodes as Shard Hosts** — Local machines hosting model shards
+- [ ] **Ollama/llama.cpp Integration** — Local inference runtimes as agent backends
+- [ ] **Proof-of-Storage as Unifying Principle** — Shared design principle for decentralized and local inference
+
+---
+
+## Phase 8: Rust Rewrite (Reference Parity)
+
+*Port the canonical Python implementation to Rust with identical behavior.*
+
+- [ ] **Port Core Systems** — Orchestrator, aggregator, NCG, R2, InjectionGuard, MAGI ported to Rust
+- [ ] **Tokio Async Runtime** — Replace FastAPI's ASGI layer with native Tokio async
+- [ ] **Python Reference Maintenance** — Python layer maintained as reference until behavioral parity verified
+
+---
+
 ## Phase: Rust Migration & telOS Substrate
 
 The long-term architectural trajectory of Maestro is a full rewrite in Rust, targeting eventual integration with **telOS** — a novel operating system being developed in parallel where *intent is the kernel ABI*. telOS has no process table, no traditional filesystem, and uses a vector database as its canonical address space. Maestro's WeightHost/WeightNode federation model maps directly onto this substrate: WeightHosts become first-class citizens of the telOS address space, resolved by semantic intent rather than PID or path.
@@ -116,6 +157,17 @@ The Rust migration is not a cosmetic port. It is a prerequisite for:
 - FFI-safe interface boundaries for telOS integration
 
 Migration strategy: the Python orchestration layer remains canonical until Rust reaches parity. Target parity milestone is defined as: quorum logic, NCG drift detection, R2 epistemic ledger, InjectionGuard, and MAGI meta-analysis all functional in Rust with identical behavior verified against the Python reference implementation.
+
+---
+
+## Phase 9: telOS Substrate Integration
+
+*Maestro as a native telOS process.*
+
+- [ ] **WeightHost/WeightNode as telOS Vector-Addressed Nodes** — Hosts resolved by capability signature in the telOS address space
+- [ ] **Quorum as Semantic Consensus over Vector Space** — Consensus operations over the vector substrate rather than HTTP network votes
+- [ ] **Epistemic Ledger as Append-Only Vector Index** — R2 ledger mapped to a time-weighted vector index
+- [ ] **Conductor / Protosynthetic Intelligence as Native telOS Process** — The Conductor pipeline running as a first-class telOS citizen
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,134 @@
+# Maestro-Orchestrator Roadmap
+
+**Current Version:** v7.4.0
+**Last Updated:** 2026-03-27
+**Maintainer:** defcon
+
+---
+
+## North Star
+
+**Distributed Perpetual Weight Orchestration** — a network of persistent AI weight hosts
+coordinated by a sovereign control plane, capable of epistemic consensus, dissent analysis,
+and self-improvement without centralized inference dependency.
+
+The thesis: **route queries to persistent weights, not weights to queries.** Every phase
+of this roadmap advances toward a world where inference is a distributed resource held by
+many, not a monopoly service rented from few.
+
+The canonical articulation of this thesis lives in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+
+---
+
+## Phase 1: Foundation (Complete)
+
+*Build the epistemic core — multi-agent consensus with quality measurement.*
+
+- [x] **Core Orchestration** — Quorum-based multi-agent orchestration with parallel agent queries, semantic similarity clustering, 66% supermajority consensus
+- [x] **Agent Council** — Four council agents (GPT-4o, Claude Sonnet 4.6, Gemini 2.5 Flash, Llama 3.3 70B) with shared async interface and swappable module isolation
+- [x] **Deliberation Engine** — Multi-round peer-aware refinement before analysis; configurable rounds (1-5), non-fatal, all downstream analysis operates on deliberated positions
+- [x] **Dissent Analysis** — Pairwise semantic distance, outlier detection, internal agreement scoring, cross-session trend analysis
+- [x] **NCG Module** — Novel Content Generation with headless baseline, drift detection, silent collapse prevention, compression alerts
+- [x] **R2 Engine** — Session scoring (strong/acceptable/weak/suspicious), consensus ledger indexing, structured improvement signal generation
+- [x] **MAGI Module** — Cross-session pattern analysis, confidence trends, collapse frequency tracking, structured recommendations
+- [x] **Self-Improvement Pipeline** — MAGI analysis -> code introspection (AST, signal-to-code) -> optimization proposals -> MAGI_VIR sandboxed validation -> promote/reject -> optional injection with InjectionGuard, rollback, and smoke testing
+- [x] **Session History** — Persistent JSON-based session and ledger records with unified data layer
+- [x] **FastAPI Backend** — Full analysis pipeline on every request; SSE streaming; REST API for sessions, MAGI, storage, self-improvement, plugins, keys
+- [x] **React Web UI** — R2 grades, quorum bar, dissent visualization, NCG drift, session browser, storage network topology, LAN discovery
+- [x] **TUI Dashboard** — Textual-based terminal UI optimized for SoC devices; mainframe-style navigation, shard network monitor, LAN discovery, cluster instance management
+- [x] **Interactive CLI** — Full orchestration pipeline in the terminal with self-improvement commands
+- [x] **Docker Containerization** — One-step deployment of backend + frontend; multi-service compose with orchestrator + shard workers + Redis + Postgres
+- [x] **Auto-Updater** — Background polling with configurable intervals, SSE notifications, auto-apply option, Docker rebuild support
+
+*Detailed version history: v0.1 through v7.4.0 — see git log for granular changelog.*
+
+---
+
+## Phase 2: Distributed Runtime (In Progress)
+
+*Make the weight persistence thesis mechanically real across multiple hosts.*
+
+- [x] **WeightHost Abstraction** — `WeightHost` dataclass with capability manifests (domain affinity, warmth state, hardware class), replacing generic "storage node" terminology throughout the codebase
+- [x] **Weight Locality Routing** — `weight_locality_score()` function computing routing preference (0.25-1.0) based on warmth and domain affinity; load-bearing in pipeline construction
+- [x] **WeightHostRegistry** — Topology-aware registry with pipeline construction, redundancy maps, heartbeat tracking, reputation integration, shard-level capability declarations
+- [x] **Proof-of-Storage** — Cryptographic challenge-response verification (PoRep, PoRes, PoI); reputation scoring integrated with R2; automatic eviction below 0.3 reputation
+- [x] **ShardAgent** — Distributed inference agent with failover; standalone node server for weight host participation
+- [x] **Cluster Instance Spawning** — TUI-driven cluster formation with auto-assigned names/IPs/shard indices, shared Docker network and Redis
+- [x] **LAN Peer Discovery** — Automatic discovery of adjacent Maestro nodes on the local network
+- [x] **Plugin Architecture** — Modular plugin lifecycle with 8 pipeline hook points, event bus, PluginContext, hook ownership tracking
+- [ ] **Interactive Sessions** — Human agent participates in deliberations alongside AI agents in real time
+- [ ] **Token-Level NCG** — Logprob-level drift measurement across all providers (OpenAI built, pending Anthropic/Google)
+- [ ] **NCG Feedback Loops** — Reshape prompts based on drift signals before they reach conversational agents
+- [ ] **WeightHost Clustering** — Multi-orchestrator coordination: multiple Maestro instances sharing a WeightHost mesh with consensus on routing decisions
+- [ ] **Docker Compose Sharding** — Configuration-driven shard topology: define model layer assignments per container in compose config rather than manual registration
+- [ ] **Plugin Marketplace** — Curated plugin registry with versioning, dependency resolution, one-click install
+- [ ] **Local Model Support** — Agent wrappers for llamacpp, Ollama, and other local inference runtimes as first-class WeightHosts
+- [ ] **ESP32 SoC Support** — Lightweight node agent for microcontrollers as edge WeightHosts
+
+---
+
+## Phase 3: Orchestra (Planned)
+
+*Make the distributed weight thesis visible and verifiable to the outside world.*
+
+Orchestra is a live, public-facing dashboard and leaderboard that visualizes AI model
+performance across the Maestro distributed network in real time. It is both a developer
+monitoring tool and a public proof of concept for the weight persistence model.
+
+See [`ORCHESTRA.md`](./ORCHESTRA.md) for the full feature specification.
+
+- [ ] **Orchestra Service** — Lightweight FastAPI sidecar collecting WeightHost metrics, consensus data, and routing decisions into a SQLite time-series store
+- [ ] **Live Leaderboard** — WeightHosts ranked by accuracy, consensus rate, dissent quality, latency, uptime, and weight persistence; filterable by hardware class
+- [ ] **Real-Time Dashboard** — WebSocket-driven live view of network health, R2 grades, MAGI analysis, and active weight host count
+- [ ] **Routing Feed** — Anonymized live stream of query routing decisions showing pipeline composition, locality scores, and multi-hop inference paths
+- [ ] **Per-Host Detail Views** — Time-series charts of individual WeightHost metrics: latency, throughput, reputation, warmth duration
+- [ ] **Thesis Visualization** — Dedicated UI elements making weight persistence tangible: cold start counts, warmth duration, query-to-weight routing paths, edge vs cloud comparison
+- [ ] **Public Deployment** — Static export for GitHub Pages / Cloudflare Pages with rate-limited public API; SEO metadata
+- [ ] **Orchestra API** — New endpoints on Maestro Core: `/api/orchestra/hosts`, `/api/orchestra/leaderboard`, `/api/orchestra/feed`, `/api/orchestra/ws`
+
+---
+
+## Phase 4: Perpetual Network (Future)
+
+*Persistent weight hosts operating as autonomous infrastructure, self-improving
+through continuous epistemic measurement.*
+
+- [ ] **Persistent WeightHosts** — Hosts that maintain warm weights across reboots via checkpoint-resume; weight state survives process lifecycle
+- [ ] **Proof-of-Storage Inference** — Extend PoI challenges to continuous background verification; hosts prove ongoing inference capability, not just data possession
+- [ ] **Cross-Session NCG Baselines** — Track "normal" headless output profiles over time to detect gradual model drift and RLHF pressure shifts
+- [ ] **Autonomous Self-Improvement (MAGI_VIR)** — Graduate from opt-in injection to autonomous threshold tuning within validated safety bounds; MAGI proposes, validates, and applies low-risk optimizations without human intervention
+- [ ] **Decentralized Consensus Layer** — Cross-host quorum: WeightHosts participate directly in epistemic consensus, not just as inference backends
+- [ ] **Multilingual Agent Specialization** — Language-specialized agents as WeightHosts with domain affinity for specific language families
+- [ ] **Reinforcement Loop** — Feed consensus outcomes and R2 quality data into fine-tuning pipelines; the network improves the models it hosts
+- [ ] **Public Demo Endpoint** — Limited-use hosted Maestro instance with transparent logging, backed by Orchestra dashboard
+- [ ] **Contributor Onboarding** — Expand `CONTRIBUTING.md` with architecture walkthrough, task tags, and first-contribution guides
+
+---
+
+## Phase: Rust Migration & telOS Substrate
+
+The long-term architectural trajectory of Maestro is a full rewrite in Rust, targeting eventual integration with **telOS** — a novel operating system being developed in parallel where *intent is the kernel ABI*. telOS has no process table, no traditional filesystem, and uses a vector database as its canonical address space. Maestro's WeightHost/WeightNode federation model maps directly onto this substrate: WeightHosts become first-class citizens of the telOS address space, resolved by semantic intent rather than PID or path.
+
+The Rust migration is not a cosmetic port. It is a prerequisite for:
+- Zero-cost orchestration at ring-adjacent latency
+- Memory safety without a GC, enabling Maestro to run as infrastructure rather than application
+- Native async with Tokio, replacing FastAPI's ASGI layer
+- FFI-safe interface boundaries for telOS integration
+
+Migration strategy: the Python orchestration layer remains canonical until Rust reaches parity. Target parity milestone is defined as: quorum logic, NCG drift detection, R2 epistemic ledger, InjectionGuard, and MAGI meta-analysis all functional in Rust with identical behavior verified against the Python reference implementation.
+
+---
+
+## Guiding Principles
+
+- **Preserve dissent** — the 66% supermajority ensures 33% dissent is always recorded and visible
+- **Prevent stagnation** — continuous measurement (R2, MAGI, NCG) catches degradation before it compounds
+- **Embrace disagreement as structure** — outlier detection is not suppression; it is classification
+- **Always show your work** — every orchestration session produces a legible epistemic record
+- **Weights are infrastructure** — treat model weights as persistent resources, not ephemeral allocations
+
+---
+
+## Community & Contributions
+
+Contributors who align with the principles of transparency and structured dissent are welcome. See `CONTRIBUTING.md` for details, or follow project essays at [substack.com/@defqon1](https://substack.com/@defqon1).

--- a/docs/maestro-whitepaper.md
+++ b/docs/maestro-whitepaper.md
@@ -61,6 +61,10 @@ The Maestro orchestration layer includes:
 
 Protosynthetic intelligence describes a system that maintains a persistent internal model of its own generative decisions, can be queried about its reasoning across arbitrarily deep context, and uses that self-model to inform future output. It is distinct from AGI and makes no claim of sentience. It represents the architectural step between reactive token prediction and genuine synthesis — a system that does not merely generate, but remembers why it chose. The WeightHost/WeightNode substrate makes this property possible by maintaining persistent in-state context across a distributed inference layer in ways that stateless API calls fundamentally cannot.
 
+### Forward Integration: Rust and telOS
+
+> The current Python implementation of Maestro is a reference architecture — a proof that the orchestration model works, not a statement that Python is the final medium. The planned Rust rewrite targets the same behavioral contract with zero-cost abstractions, making Maestro suitable for deployment as infrastructure rather than application. The endpoint of this migration is integration with **telOS**: a novel operating system in active development where intent is the kernel ABI, the address space is a vector database, and there is no process table or filesystem. In this environment, Maestro's WeightHost/WeightNode model resolves naturally — nodes are found by semantic intent, quorum is a vector consensus operation, and the epistemic ledger is an append-only semantic index. Protosynthetic intelligence at that layer is not emulated. It is native.
+
 ---
 
 ## The 66% Rule: Why Consensus is Not the Goal


### PR DESCRIPTION
## Summary

This PR adds comprehensive roadmap documentation and expands architectural documentation to articulate the long-term vision for Maestro as distributed weight infrastructure, including planned integration with the telOS substrate.

## Key Changes

- **New ROADMAP.md**: Comprehensive 9-phase roadmap spanning from current v7.4.0 through planned Rust rewrite and telOS substrate integration
  - Phase 1 (Complete): Foundation with epistemic core, multi-agent consensus, and self-improvement
  - Phase 2 (In Progress): Distributed runtime with WeightHost abstraction and proof-of-storage
  - Phases 3-9: Orchestra dashboard, perpetual network, plugin architecture, Rust migration, and telOS integration
  - Includes guiding principles emphasizing dissent preservation, continuous measurement, and weights-as-infrastructure

- **ARCHITECTURE.md**: Added "Long-Term Substrate: telOS" section explaining convergence between Maestro's WeightHost/WeightNode model and telOS's vector-addressed address space
  - Clarifies how quorum consensus maps to semantic operations over vector substrate
  - Explains R2 epistemic ledger mapping to append-only vector index
  - Establishes telOS integration as intended end state, not speculative

- **maestro-whitepaper.md**: Added "Forward Integration: Rust and telOS" section
  - Positions Python implementation as reference architecture
  - Establishes Rust as intermediate target before telOS substrate integration

## Notable Details

- Roadmap uses checkbox notation to distinguish completed (Phase 1), in-progress (Phase 2), and planned (Phases 3-9) work
- Maintains clear distinction between near-term distributed runtime goals and long-term substrate convergence
- Emphasizes that design decisions should be evaluated against Python→Rust→telOS transition path
- Includes contributor onboarding and community engagement guidance

https://claude.ai/code/session_01QUNUSg2WjBaw6RuTbmgtZk